### PR TITLE
fix: exclude commons-lang3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,12 @@
             <artifactId>usm4uvms</artifactId>
             <type>jar</type>
             <version>${uvms.usm4uvms.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
Geoserver already has commons-lang3 as a (transitive) dependency and the one that UVMS is bringing in clashes with commons-text.