### PR TITLE
fix: deployment now starts on 2.27.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>fish.focus.uvms.geoserver.web.overlay</groupId>
     <artifactId>gs-web-app</artifactId>
-    <version>2.25.3.3-SNAPSHOT</version>
+    <version>2.27.1.0-SNAPSHOT</version>
     <packaging>war</packaging>
     <url>https://github.com/FocusFish/geoserver-overlay</url>
     <scm>
@@ -49,43 +49,19 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlets</artifactId>
+            <version>10.0.25</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-util</artifactId>
+            <version>10.0.25</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.8.1</version>
-                <executions>
-                    <execution>
-                        <id>copy</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>copy</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.eclipse.jetty</groupId>
-                                    <artifactId>jetty-servlets</artifactId>
-                                    <version>9.4.36.v20210114</version>
-                                    <outputDirectory>
-                                        ${project.build.directory}/${project.artifactId}-${project.version}/WEB-INF/lib/
-                                    </outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.eclipse.jetty</groupId>
-                                    <artifactId>jetty-util</artifactId>
-                                    <version>9.4.36.v20210114</version>
-                                    <outputDirectory>
-                                        ${project.build.directory}/${project.artifactId}-${project.version}/WEB-INF/lib/
-                                    </outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>

--- a/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,7 @@
+<jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.2">
+    <deployment>
+        <exclude-subsystems>
+            <subsystem name="logging"/>
+        </exclude-subsystems>
+    </deployment>
+</jboss-deployment-structure>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -12,7 +12,7 @@
         <!-- Meaning of the different values :
 
              PARTIAL-BUFFER2
-             - Partially buffers the first xKb to disk. Once that has buffered, the the
+             - Partially buffers the first xKb to disk. Once that has buffered, the
                result is streamed to the user. This will allow for most errors to be caught
                early.
 
@@ -97,8 +97,8 @@
     </filter>
 
     <filter>
-        <filter-name>xFrameOptionsFilter</filter-name>
-        <filter-class>org.geoserver.filters.XFrameOptionsFilter</filter-class>
+        <filter-name>securityHeadersFilter</filter-name>
+        <filter-class>org.geoserver.filters.SecurityHeadersFilter</filter-class>
     </filter>
 
     <filter>
@@ -109,7 +109,7 @@
                  If a mime type matches any of the regular expressions then it will be compressed.
                  -->
             <param-name>compressed-types</param-name>
-            <param-value>text/.*,.*xml.*,application/json,application/x-javascript</param-value>
+            <param-value>text/.*,.*xml.*,application/json,application/javascript</param-value>
         </init-param>
     </filter>
 
@@ -243,7 +243,7 @@
     </filter-mapping>
 
     <filter-mapping>
-        <filter-name>xFrameOptionsFilter</filter-name>
+        <filter-name>securityHeadersFilter</filter-name>
         <url-pattern>/*</url-pattern>
     </filter-mapping>
 


### PR DESCRIPTION
Geoserver deployment didn't start due to Wildfly supplying an old version of log4j2 API.

In addition, updated web.xml to follow the source with UVMS specific additions.

Refs: FART-591